### PR TITLE
Support for explicit proxy via ansible variable instead of environment variable

### DIFF
--- a/plugins/connection/httpapi.py
+++ b/plugins/connection/httpapi.py
@@ -101,6 +101,12 @@ options:
     default: true
     vars:
     - name: ansible_httpapi_use_proxy
+  explicit_proxy:
+    type: string
+    description:
+    - Define an explicit proxy for the connection. Will reset HTTPS_PROXY and HTTP_PROXY env variable
+    vars:
+    - name: ansible_httpapi_explicit_proxy
   ciphers:
     description:
       - SSL/TLS Ciphers to use for requests
@@ -156,6 +162,7 @@ options:
 """
 
 from io import BytesIO
+from os import environ
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes
@@ -283,6 +290,11 @@ class Connection(NetworkConnectionBase):
             headers={},
         )
         url_kwargs.update(kwargs)
+
+        explicit_proxy = self.get_option("explicit_proxy")
+        if explicit_proxy and explicit_proxy != "":
+            environ['HTTPS_PROXY'] = explicit_proxy
+            environ['HTTP_PROXY']  = explicit_proxy
 
         ciphers = self.get_option("ciphers")
         if ciphers:


### PR DESCRIPTION
Hi,

Following this issue:
https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/240

Since httpapi is running as an Ansible plugin, the only way to specify a proxy is via the HTTPS_PROXY globally for the whole ansible process. Since we need  to specify a different proxy server for each host (or group of hosts), a new httpapi variable is needed so we could dynamically set it based on host/group vars.

Example usage:
- name: xxx
  hosts:
    - xxx
  gather_facts: True
  collections:
    - fortinet.fortios
  vars:
    ansible_httpapi_port: 443
    ansible_httpapi_use_ssl: True
    ansible_httpapi_validate_certs: False
    ansible_httpapi_use_proxy: True
    ansible_network_os: fortinet.fortios.fortios
    ansible_network_import_modules: False
    ansible_httpapi_explicit_proxy: "{{ ps }}"

This patch creates a dependency with the os python package. Maybe it could be improved. But so far it seems functionnal.

Hope that helps.
